### PR TITLE
remove argument from print-function

### DIFF
--- a/lattice/graph.hpp
+++ b/lattice/graph.hpp
@@ -156,7 +156,7 @@ public:
     return graph(basis::simple(dim), unitcell::simple(dim), length);
   }
 
-  void print(std::ostream& os) const {
+  void print() const {
     std::cout << "dimension: " << dimension() << std::endl
               << "number of sites: " << num_sites() << std::endl
               << "number of bonds: " << num_bonds() << std::endl;


### PR DESCRIPTION
- lattice/graph.hpp内で定義されているクラス(graph)のメンバ関数printの引数は不要に思えたので消去しました.